### PR TITLE
Fix validation to handle Swagger files without info fields (Issue #14)

### DIFF
--- a/internal/adapters/swagger/parser.go
+++ b/internal/adapters/swagger/parser.go
@@ -33,15 +33,6 @@ func (p *Parser) Validate(doc *models.SwaggerDoc) error {
 		return errors.New("not a valid Swagger/OpenAPI document: missing 'swagger' or 'openapi' field")
 	}
 
-	// Validate required fields
-	if doc.Info.Title == "" {
-		return errors.New("info.title is required")
-	}
-
-	if doc.Info.Version == "" {
-		return errors.New("info.version is required")
-	}
-
 	// Check if there are any paths
 	if len(doc.Paths) == 0 {
 		return errors.New("no paths defined in the document")

--- a/internal/adapters/swagger/parser_test.go
+++ b/internal/adapters/swagger/parser_test.go
@@ -133,6 +133,23 @@ func TestParser_Validate(t *testing.T) {
 		},
 	}
 
+	// Create a document with missing info fields
+	missingInfoFieldsDoc := &models.SwaggerDoc{
+		Swagger: "2.0",
+		Info:    models.Info{}, // Empty info
+		Paths: map[string]models.PathItem{
+			"/test": {
+				Get: &models.Operation{
+					Responses: map[string]models.Response{
+						"200": {
+							Description: "OK",
+						},
+					},
+				},
+			},
+		},
+	}
+
 	tests := []struct {
 		name    string
 		doc     *models.SwaggerDoc
@@ -167,6 +184,11 @@ func TestParser_Validate(t *testing.T) {
 			name:    "invalid path parameter - not required",
 			doc:     invalidPathParamDoc,
 			wantErr: true,
+		},
+		{
+			name:    "missing info fields",
+			doc:     missingInfoFieldsDoc,
+			wantErr: false, // Should NOT error anymore with our fix
 		},
 	}
 
@@ -250,28 +272,28 @@ func TestParser_ExtractOperations(t *testing.T) {
 
 	// Expected results
 	tests := []struct {
-		name             string
-		tag              string
-		expectedCount    int
-		containsPath     string
-		containsMethod   string
-		expectedContains bool
+		name              string
+		tag               string
+		expectedCount     int
+		containsPath      string
+		containsMethod    string
+		expectedContains  bool
 	}{
 		{
-			name:             "pets tag operations",
-			tag:              "pets",
-			expectedCount:    5, // GET /pets, POST /pets, GET /pets/{petId}, PUT /pets/{petId}, DELETE /pets/{petId}
-			containsPath:     "/pets",
-			containsMethod:   "GET",
-			expectedContains: true,
+			name:              "pets tag operations",
+			tag:               "pets",
+			expectedCount:     5, // GET /pets, POST /pets, GET /pets/{petId}, PUT /pets/{petId}, DELETE /pets/{petId}
+			containsPath:      "/pets",
+			containsMethod:    "GET",
+			expectedContains:  true,
 		},
 		{
-			name:             "non-existent tag",
-			tag:              "non-existent",
-			expectedCount:    0,
-			containsPath:     "",
-			containsMethod:   "",
-			expectedContains: false,
+			name:              "non-existent tag",
+			tag:               "non-existent",
+			expectedCount:     0,
+			containsPath:      "",
+			containsMethod:    "",
+			expectedContains:  false,
 		},
 	}
 


### PR DESCRIPTION
## Summary

This PR addresses Issue #14 by removing the validation requirements for `info.title` and `info.version` fields in Swagger documents. While the OpenAPI specification considers these fields required, our tool should be more flexible to handle incomplete or draft Swagger files.

## Changes

1. Modified the `Validate` method in `parser.go` to remove the validation checks for `info.title` and `info.version` fields
2. Added a test case in `parser_test.go` to verify that a Swagger document with missing info fields is now accepted by the validator

## Testing

The new test case specifically verifies that a Swagger document with empty info fields passes validation. All existing tests still pass, ensuring we haven't broken any existing functionality.

## Related Issues

Fixes #14
